### PR TITLE
fix-var-optimization

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - 'v*'
   pull_request:
     branches:
       - main
@@ -65,6 +63,7 @@ jobs:
       run: task coverage
 
     - name: Benchmark
+      if: github.event_name == 'pull_request'
       run: task benchmark
 
   update-readme:

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -33,7 +33,7 @@ const (
 
 // rootCmd represents the base command when called without any subcommands.
 var rootCmd = &cobra.Command{
-	Version: "v1.2.1",
+	Version: "v1.2.2",
 	Use:     "bicep-docs",
 	Short:   "bicep-docs is a command-line tool that generates documentation for Bicep templates.",
 	Long: `bicep-docs is a command-line tool that generates documentation for Bicep templates.

--- a/internal/template/parse_test.go
+++ b/internal/template/parse_test.go
@@ -64,7 +64,6 @@ func TestParseTemplates(t *testing.T) {
 			Description: strPtr("This is a test template."),
 		},
 	}
-
 	extendedTemplate := &types.Template{
 		FileName: "testdata/extended.bicep",
 		Modules: []types.Module{
@@ -206,6 +205,49 @@ func TestParseTemplates(t *testing.T) {
 			Description: strPtr("Test template with loop constructs"),
 		},
 	}
+	variableOptimizationTemplate := &types.Template{
+		FileName: "testdata/var_optimization.bicep",
+		Parameters: []types.Parameter{
+			{
+				Name: "servicePlanName",
+				Type: "string",
+				Metadata: &types.Metadata{
+					Description: strPtr("Name of the App Service Plan to host Web-App on"),
+				},
+			},
+		},
+		Resources: []types.Resource{
+			{
+				SymbolicName: "servicePlan",
+				Type:         "Microsoft.Web/serverfarms",
+				Description:  "Get App Service Plan Object",
+			},
+		},
+		Variables: []types.Variable{
+			{
+				Name:        "isZoneRedundant",
+				Description: "Get resilience options from Service Plan",
+			},
+			{
+				Name:        "reserved",
+				Description: "",
+			},
+		},
+		Outputs: []types.Output{
+			{
+				Name: "isZoneRedundant",
+				Type: "bool",
+			},
+			{
+				Name: "reserved",
+				Type: "bool",
+			},
+		},
+		Metadata: &types.Metadata{
+			Name:        strPtr("var_optimization"),
+			Description: strPtr("Test template with variable optimization"),
+		},
+	}
 
 	type args struct {
 		bicepFile string
@@ -242,6 +284,15 @@ func TestParseTemplates(t *testing.T) {
 				armFile:   "testdata/loops.json",
 			},
 			want:    loopsTemplate,
+			wantErr: false,
+		},
+		{
+			name: "var_optimization_template",
+			args: args{
+				bicepFile: "testdata/var_optimization.bicep",
+				armFile:   "testdata/var_optimization.json",
+			},
+			want:    variableOptimizationTemplate,
 			wantErr: false,
 		},
 		{

--- a/internal/template/testdata/var_optimization.bicep
+++ b/internal/template/testdata/var_optimization.bicep
@@ -1,0 +1,17 @@
+metadata name = 'var_optimization'
+metadata description = 'Test template with variable optimization'
+
+@description('Name of the App Service Plan to host Web-App on')
+param servicePlanName string
+
+@description('Get resilience options from Service Plan')
+var isZoneRedundant = servicePlan.properties.zoneRedundant
+var reserved = servicePlan.properties.reserved
+
+@description('Get App Service Plan Object')
+resource servicePlan 'Microsoft.Web/serverfarms@2024-04-01' existing = {
+  name: servicePlanName
+}
+
+output isZoneRedundant bool = isZoneRedundant
+output reserved bool = reserved

--- a/internal/template/testdata/var_optimization.json
+++ b/internal/template/testdata/var_optimization.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.31.92.45157",
+      "templateHash": "11802698965472727578"
+    },
+    "name": "var_optimization",
+    "description": "Test template with variable optimization"
+  },
+  "parameters": {
+    "servicePlanName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the App Service Plan to host Web-App on"
+      }
+    }
+  },
+  "resources": [],
+  "outputs": {
+    "isZoneRedundant": {
+      "type": "bool",
+      "value": "[reference(resourceId('Microsoft.Web/serverfarms', parameters('servicePlanName')), '2024-04-01').zoneRedundant]"
+    },
+    "reserved": {
+      "type": "bool",
+      "value": "[reference(resourceId('Microsoft.Web/serverfarms', parameters('servicePlanName')), '2024-04-01').reserved]"
+    }
+  }
+}


### PR DESCRIPTION
## Issue
When variables reference resource properties in a Bicep template, the variables are optimized away during ARM template compilation. This was causing bicep-docs to fail with the error "error parsing Bicep variables" as it expected a 1:1 match between Bicep and ARM template variables.

## Changes
- Removed the strict variable length comparison check in `ParseTemplates()`
- Use variables parsed from Bicep file directly since ARM template might optimize them away
- Added test case `var_optimization_template` to verify the behavior

Example scenario that now works:
```bicep
var isZoneRedundant = servicePlan.properties.zoneRedundant
var reserved = servicePlan.properties.reserved

resource servicePlan 'Microsoft.Web/serverfarms@2023-01-01' existing = {
    name: servicePlanName
}
```

This gets compiled to ARM template without variables section:
```json
{
  "outputs": {
    "isZoneRedundant": {
      "value": "[reference(...).zoneRedundant]"
    }
  }
}
```

## Testing
- Added dedicated test case for variable optimization scenario
- Verified that variable descriptions are preserved
- Existing tests continue to pass

## Related Issues
Fixes #38 - Error when parsing variables that reference resource properties

## Notes
This is a normal Bicep optimization where variables that reference resource properties are compiled directly into reference() calls in the ARM template. The fix allows bicep-docs to handle this pattern correctly while maintaining all variable information from the source Bicep file.