### PR TITLE
support-uddt-properties

### DIFF
--- a/.github/scripts/coverage-badge.sh
+++ b/.github/scripts/coverage-badge.sh
@@ -3,7 +3,7 @@
 # This script generates a code coverage badge and adds it to the README.md file.
 
 # Find the coverage percentage
-go test ./... -coverprofile coverage.out --covermode count
+go test ./internal/markdown ./internal/template ./internal/cli -coverprofile coverage.out --covermode count
 COVERAGE=$(go tool cover -func=coverage.out | grep total: | grep -Eo '[0-9]+\.[0-9]+')
 COLOR=orange
 if (( $(echo "$COVERAGE <= 50" | bc -l) )) ; then

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,6 +62,18 @@ jobs:
       id: coverage
       run: task coverage
 
+    - name: Run Gosec Security Scanner
+      uses: securego/gosec@master
+      with:
+        # we let the report trigger content trigger a failure using the GitHub Security features.
+        args: '-no-fail -fmt sarif -out results.sarif ./...'
+    
+    - name: Upload SARIF file
+      uses: github/codeql-action/upload-sarif@v2
+      with:
+        # Path to SARIF file relative to the root of the repository
+        sarif_file: results.sarif
+    
     - name: Benchmark
       if: github.event_name == 'pull_request'
       run: task benchmark

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,6 +54,10 @@ jobs:
     - name: Install Go tools
       run: task setup:test
 
+    - name: Security scan
+      id: security
+      run: task security
+    
     - name: Test
       id: test
       run: task test
@@ -61,18 +65,6 @@ jobs:
     - name: Code coverage
       id: coverage
       run: task coverage
-
-    - name: Run Gosec Security Scanner
-      uses: securego/gosec@master
-      with:
-        # we let the report trigger content trigger a failure using the GitHub Security features.
-        args: '-no-fail -fmt sarif -out results.sarif ./...'
-    
-    - name: Upload SARIF file
-      uses: github/codeql-action/upload-sarif@v2
-      with:
-        # Path to SARIF file relative to the root of the repository
-        sarif_file: results.sarif
     
     - name: Benchmark
       if: github.event_name == 'pull_request'

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ dist/
 icons/
 .DS_Store
 .vscode/
+test/

--- a/.gosec.json
+++ b/.gosec.json
@@ -1,0 +1,7 @@
+{
+  "global": {
+    "nosec": "enabled",
+    "audit": "enabled",
+    "exclude": "G204,G304"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ To run bicep-docs, either the Azure CLI or the Bicep CLI must be [installed](htt
 
 | CLI   | Minimum Required Version |
 | ----- | ------------------------ |
-| Azure | 2.64.0                   |
-| Bicep | 0.29.0                   |
+| Azure | 2.69.0                   |
+| Bicep | 0.33.0                   |
 
 ## Usage
 
@@ -139,6 +139,14 @@ table of parameters
 ## User Defined Data Types (UDDTs)
 
 table of UDDTs
+
+For every UDDT u with properties, a sub-section is created:
+
+### u
+
+table of properties
+
+...
 
 ## User Defined Functions (UDFs)
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -34,6 +34,7 @@ tasks:
     desc: Install necessary testing tools
     cmds:
       - go install gotest.tools/gotestsum@latest
+      - go install golang.org/x/tools/cmd/deadcode@latest
       - go install github.com/securego/gosec/v2/cmd/gosec@latest
     silent: true
 
@@ -68,6 +69,16 @@ tasks:
     desc: Run tests for template package
     dir: ./internal/template
     cmd: gotestsum -f testname
+    silent: true
+
+  deadcode:
+    desc: Run deadcode
+    cmd: deadcode ./...
+    silent: true
+
+  security:
+    desc: Run gosec
+    cmd: gosec -conf .gosec.json ./...
     silent: true
 
   coverage:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -34,7 +34,6 @@ tasks:
     desc: Install necessary testing tools
     cmds:
       - go install gotest.tools/gotestsum@latest
-      - go install github.com/axw/gocov/gocov@latest
       - go install github.com/securego/gosec/v2/cmd/gosec@latest
     silent: true
 
@@ -73,7 +72,23 @@ tasks:
 
   coverage:
     desc: Generate coverage information for all packages
-    cmd: gocov test ./... | gocov report
+    cmd: go test -cover ./internal/markdown ./internal/template ./internal/cli
+    silent: true
+
+  coverage:markdown:
+    desc: Generate coverage information for markdown package
+    cmds:
+      - go test -coverprofile=coverage.out ./internal/markdown
+      - go tool cover -func=coverage.out
+      - rm coverage.out
+    silent: true
+
+  coverage:template:
+    desc: Generate coverage information for template package
+    cmds:
+      - go test -coverprofile=coverage.out ./internal/template
+      - go tool cover -func=coverage.out
+      - rm coverage.out
     silent: true
 
   ### Benchmark ###

--- a/examples/directory/README.md
+++ b/examples/directory/README.md
@@ -16,7 +16,7 @@ bicep
 
 ## Running the Example
 
-1. Navigate to the `directory/bicep` directory.
+1. Navigate to the `examples/directory/bicep` directory.
 2. Run the following command:
 
 ```bash

--- a/examples/file/README.md
+++ b/examples/file/README.md
@@ -5,7 +5,7 @@ providing the output file name.
 
 ## Running the Example
 
-1. Navigate to the `file/bicep` directory.
+1. Navigate to the `examples/file/bicep` directory.
 2. Run the following command:
 
 ```bash

--- a/examples/file/bicep/README.md
+++ b/examples/file/bicep/README.md
@@ -42,9 +42,17 @@ module reference_name 'path_to_module | container_registry_reference' = {
 
 ## User Defined Data Types (UDDTs)
 
+| Name | Type | Description | Properties |
+| --- | --- | --- | --- |
+| customType | object | Custom type for the input parameter. | [View Properties](#customtype) |
+| positiveInt | int | Positive integer (> 0). |  |
+
+### customType
+
 | Name | Type | Description |
 | --- | --- | --- |
-| positiveInt | int | Positive integer (> 0). |
+| property1 | string | This is a string property of the custom type. |
+| property2 | positiveInt (uddt) | This is a positive integer property of the custom type. |
 
 ## User Defined Functions (UDFs)
 
@@ -56,7 +64,7 @@ module reference_name 'path_to_module | container_registry_reference' = {
 
 | Name | Description |
 | --- | --- |
-| test_number | Doubles a positive integer. |
+| test_number |  |
 
 ## Outputs
 

--- a/examples/file/bicep/main.bicep
+++ b/examples/file/bicep/main.bicep
@@ -20,10 +20,19 @@ type positiveInt = int
 @sys.description('Doubles a positive integer.')
 func double(input positiveInt) positiveInt => input * 2
 
+@sys.description('Custom type for the input parameter.')
+type customType = {
+  @sys.description('This is a string property of the custom type.')
+  property1: string
+
+  @sys.description('This is a positive integer property of the custom type.')
+  property2: positiveInt
+}
+
 var test_number = 10
 
 @sys.description('This is a test resource.')
-resource st 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+resource st 'Microsoft.Storage/storageAccounts@2023-05-01' = {
   name: name
   location: location
   sku: {

--- a/examples/sections/README.md
+++ b/examples/sections/README.md
@@ -5,7 +5,7 @@ providing the output file name and utilizing the sections' arguments.
 
 ## Include Sections
 
-1. Navigate to the `file/bicep` directory.
+1. Navigate to the `examples/sections/bicep` directory.
 2. Run the following command:
 
 ```bash
@@ -17,11 +17,11 @@ bicep-docs --input main.bicep --output include_sections.md --verbose --include-s
 ## Exclude Sections
 
 
-1. Navigate to the `file/bicep` directory.
+1. Navigate to the `examples/sections/bicep` directory.
 2. Run the following command:
 
 ```bash
 bicep-docs --input main.bicep --output exclude_sections.md --verbose --exclude-sections description,usage,resources,modules,udfs,uddts,variables
 ```
 
-> NOTE: the sections incuded will be: default - excuded, where the default sections are: description, usage, modules, resources, parameters, udfs, uddts, variables, outputs.
+> NOTE: the sections included will be: default - excluded, where the default sections are: description, usage, modules, resources, parameters, udfs, uddts, variables, outputs.

--- a/examples/sections/bicep/main.bicep
+++ b/examples/sections/bicep/main.bicep
@@ -23,7 +23,7 @@ func double(input positiveInt) positiveInt => input * 2
 var test_number = 10
 
 @sys.description('This is a test resource.')
-resource st 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+resource st 'Microsoft.Storage/storageAccounts@2023-05-01' = {
   name: name
   location: location
   sku: {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -33,7 +33,7 @@ const (
 
 // rootCmd represents the base command when called without any subcommands.
 var rootCmd = &cobra.Command{
-	Version: "v1.2.2",
+	Version: "v1.3.0",
 	Use:     "bicep-docs",
 	Short:   "bicep-docs is a command-line tool that generates documentation for Bicep templates.",
 	Long: `bicep-docs is a command-line tool that generates documentation for Bicep templates.

--- a/internal/markdown/create_test.go
+++ b/internal/markdown/create_test.go
@@ -132,6 +132,29 @@ func TestCreateFile(t *testing.T) {
 					Description: func() *string { s := "This is a user defined type."; return &s }(),
 				},
 			},
+			{
+				Name: "custom_type",
+				Type: "object",
+				Metadata: &types.Metadata{
+					Description: func() *string { s := "This is a user defined type with properties."; return &s }(),
+				},
+				Properties: []types.UserDefinedDataTypeProperty{
+					{
+						Name: "property1",
+						Type: "string",
+						Metadata: &types.Metadata{
+							Description: func() *string { s := "This is a property of a user defined type."; return &s }(),
+						},
+					},
+					{
+						Name: "property_2",
+						Type: "#/definitions/positiveInt",
+						Metadata: &types.Metadata{
+							Description: func() *string { s := "This is another property of a user defined type which uses ref."; return &s }(),
+						},
+					},
+				},
+			},
 		},
 		UserDefinedFunctions: []types.UserDefinedFunction{
 			{

--- a/internal/markdown/testdata/extended.md
+++ b/internal/markdown/testdata/extended.md
@@ -42,10 +42,18 @@ module reference_name 'path_to_module | container_registry_reference' = {
 
 ## User Defined Data Types (UDDTs)
 
+| Name | Type | Description | Properties |
+| --- | --- | --- | --- |
+| pint | positiveInt (uddt) | This is a user defined type (alias). |  |
+| positiveInt | int | This is a user defined type. |  |
+| custom_type | object | This is a user defined type with properties. | [View Properties](#custom_type) |
+
+### custom_type
+
 | Name | Type | Description |
 | --- | --- | --- |
-| pint | positiveInt (uddt) | This is a user defined type (alias). |
-| positiveInt | int | This is a user defined type. |
+| property1 | string | This is a property of a user defined type. |
+| property_2 | positiveInt (uddt) | This is another property of a user defined type which uses ref. |
 
 ## User Defined Functions (UDFs)
 

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -71,7 +71,21 @@ type Parameter struct {
 // The name is the name of the user defined data type.
 // The type is the type of the user defined data type (e.g. "object" or even including other user defined types).
 // The metadata part is the optional metadata part of the user defined data type (just the description).
+// The properties are the properties of the user defined data type (e.g. fields in an object).
 type UserDefinedDataType struct {
+	Name       string                        `json:"-"`
+	Type       string                        `json:"-"`
+	Metadata   *Metadata                     `json:"metadata"`
+	Properties []UserDefinedDataTypeProperty `json:"-"`
+}
+
+// UserDefinedDataTypeProperty is a struct that contains the information about a property of a user defined data type.
+// A property has a name, a type and an optional metadata part.
+//
+// The name is the name of the property.
+// The type is the type of the property (e.g. "string" or even a user defined type).
+// The metadata part is the optional metadata part of the property (just the description).
+type UserDefinedDataTypeProperty struct {
 	Name     string    `json:"-"`
 	Type     string    `json:"-"`
 	Metadata *Metadata `json:"metadata"`


### PR DESCRIPTION
## Description
This pull request support for properties in UserDefinedDataType, enhancing its functionality and usability. The changes include the addition of properties to the UserDefinedDataType struct, allowing for the definition of fields within user-defined types. Furthermore, unmarshaling capabilities for these properties have been implemented in both UserDefinedDataType and UserDefinedDataTypeProperty, enabling the processing of JSON objects that include these properties. Additionally, the markdown generation functions have been refactored to include header types for sections, improving the structure and readability of the generated markdown. The test data has also been updated to ensure comprehensive coverage of the new features. Lastly, the 'test/' directory has been added to the .gitignore file to maintain project cleanliness.

## Related Issue
#47

## Motivation and Context
This change is required to improve the flexibility and usability of user-defined data types within the application. By allowing properties to be defined, users can create more complex and structured data types that better fit their needs. The enhancements to markdown generation also contribute to better documentation practices.

## How Has This Been Tested?
The changes have been tested by updating the test data to include user-defined data types with properties. All relevant tests have been executed to ensure that the new features work as intended and do not introduce any regressions. The markdown generation has also been tested to verify that the new header types are correctly implemented.

## Screenshots (if appropriate)
N/A

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.