### PR TITLE
support-nullable-types

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -33,7 +33,7 @@ const (
 
 // rootCmd represents the base command when called without any subcommands.
 var rootCmd = &cobra.Command{
-	Version: "v1.3.1",
+	Version: "v1.3.2",
 	Use:     "bicep-docs",
 	Short:   "bicep-docs is a command-line tool that generates documentation for Bicep templates.",
 	Long: `bicep-docs is a command-line tool that generates documentation for Bicep templates.

--- a/internal/markdown/create_test.go
+++ b/internal/markdown/create_test.go
@@ -109,11 +109,26 @@ func TestCreateFile(t *testing.T) {
 		},
 		Parameters: []types.Parameter{
 			{
-				Name:         "test_parameter",
+				Name: "required",
+				Type: "string",
+				Metadata: &types.Metadata{
+					Description: func() *string { s := "This is a required parameter."; return &s }(),
+				},
+			},
+			{
+				Name:     "nullable",
+				Type:     "string",
+				Nullable: true,
+				Metadata: &types.Metadata{
+					Description: func() *string { s := "This is a nullable parameter."; return &s }(),
+				},
+			},
+			{
+				Name:         "optional",
 				Type:         "string",
 				DefaultValue: "test",
 				Metadata: &types.Metadata{
-					Description: &parameterDescription,
+					Description: func() *string { s := "This is an optional parameter."; return &s }(),
 				},
 			},
 		},

--- a/internal/markdown/testdata/extended.md
+++ b/internal/markdown/testdata/extended.md
@@ -13,9 +13,11 @@ module reference_name 'path_to_module | container_registry_reference' = {
   name: 'deployment_name'
   params: {
     // Required parameters
+    required:
 
     // Optional parameters
-    test_parameter: 'test'
+    nullable: null
+    optional: 'test'
   }
 }
 ```
@@ -38,7 +40,9 @@ module reference_name 'path_to_module | container_registry_reference' = {
 
 | Name | Type | Description | Default |
 | --- | --- | --- | --- |
-| test_parameter | string | This is a test parameter. | "test" |
+| required | string | This is a required parameter. |  |
+| nullable | string | This is a nullable parameter. | null |
+| optional | string | This is an optional parameter. | "test" |
 
 ## User Defined Data Types (UDDTs)
 

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -52,42 +52,48 @@ type Resource struct {
 }
 
 // Parameter is a struct that contains the information about a parameter.
-// A parameter has a name, type, an optional default value and an optional metadata part.
+// A parameter has a name, type, an optional default value, nullable flag, and an optional metadata part.
 //
 // The name is the name of the parameter.
 // The type is the type of the parameter (e.g. "string" or even a user defined type).
 // The default value is the optional default value of the parameter.
+// The nullable flag indicates if the parameter can be null.
 // The metadata part is the optional metadata part of the parameter (just the description).
 type Parameter struct {
 	Name         string    `json:"-"`
 	Type         string    `json:"-"`
 	DefaultValue any       `json:"defaultValue"`
+	Nullable     bool      `json:"nullable"`
 	Metadata     *Metadata `json:"metadata"`
 }
 
 // UserDefinedDataType (UDDT) is a struct that contains the information about a user defined data type.
-// A user defined data type has a name, a type and an optional metadata part.
+// A user defined data type has a name, type, nullable flag, list of properties, and an optional metadata part.
 //
 // The name is the name of the user defined data type.
 // The type is the type of the user defined data type (e.g. "object" or even including other user defined types).
-// The metadata part is the optional metadata part of the user defined data type (just the description).
+// The nullable flag indicates if the user defined data type can be null.
 // The properties are the properties of the user defined data type (e.g. fields in an object).
+// The metadata part is the optional metadata part of the user defined data type (just the description).
 type UserDefinedDataType struct {
 	Name       string                        `json:"-"`
 	Type       string                        `json:"-"`
-	Metadata   *Metadata                     `json:"metadata"`
+	Nullable   bool                          `json:"nullable"`
 	Properties []UserDefinedDataTypeProperty `json:"-"`
+	Metadata   *Metadata                     `json:"metadata"`
 }
 
 // UserDefinedDataTypeProperty is a struct that contains the information about a property of a user defined data type.
-// A property has a name, a type and an optional metadata part.
+// A property has a name, type, nullable flag, and an optional metadata part.
 //
 // The name is the name of the property.
 // The type is the type of the property (e.g. "string" or even a user defined type).
+// The nullable flag indicates if the property can be null.
 // The metadata part is the optional metadata part of the property (just the description).
 type UserDefinedDataTypeProperty struct {
 	Name     string    `json:"-"`
 	Type     string    `json:"-"`
+	Nullable bool      `json:"nullable"`
 	Metadata *Metadata `json:"metadata"`
 }
 
@@ -118,13 +124,16 @@ type Variable struct {
 }
 
 // Output is a struct that contains the information about an output.
-// An output has a type and an optional metadata part.
+// An output has a name, type, nullable flag, and an optional metadata part.
 //
+// The name is the name of the output.
 // The type is the type of the output (e.g. "string").
+// The nullable flag indicates if the output can be null.
 // The metadata part is the optional metadata part of the output (just the description).
 type Output struct {
 	Name     string    `json:"-"`
 	Type     string    `json:"-"`
+	Nullable bool      `json:"nullable"`
 	Metadata *Metadata `json:"metadata"`
 }
 


### PR DESCRIPTION
## Description
This request introduces support for nullable types within the codebase. A nullable flag has been added to the `Parameter`, `UserDefinedDataType`, `UserDefinedDataTypeProperty`, and `Output` structs, allowing them to indicate whether they can accept null values. This enhancement provides greater flexibility in handling optional values throughout the application.

Additionally, the markdown generation process has been improved to accommodate nullable parameters. A switch statement has been introduced to manage default values more effectively, ensuring that nullable parameters are accurately represented as "null". The logic for required parameters has also been updated to consider both default values and nullability, which enhances the robustness of the parameter documentation.

Furthermore, the parameter definitions in the test cases have been refactored for improved clarity and consistency. The renaming of "test_parameter" to "required" and the addition of a "nullable" parameter, along with updated descriptions, align the test data with the expected usage of parameters.

## Related Issue
#51

## Motivation and Context
This change is required to enhance the type definitions and improve the handling of optional values within the application. By supporting nullable types, we can provide more accurate and flexible data structures, which is essential for robust application behavior and documentation.

## How Has This Been Tested?
The changes have been tested by updating the parameter definitions in the test cases to reflect the new nullable functionality. All tests have been run to ensure that the new logic for handling nullable parameters and default values works as intended, and that existing functionality remains unaffected.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.