### PR TITLE
refactor: remove debug print statement from markdown.go

### DIFF
--- a/internal/markdown/markdown.go
+++ b/internal/markdown/markdown.go
@@ -321,7 +321,6 @@ func generateUsageSection(template *types.Template) (string, error) {
 	// Optional parameters (with a default value).
 	builder.WriteString("\n    // Optional parameters\n")
 	for _, parameter := range template.Parameters {
-		fmt.Println(parameter.Name)
 		if parameter.DefaultValue == nil && !parameter.Nullable {
 			continue
 		}


### PR DESCRIPTION
Eliminate the debug print statement for parameter names in the 
generateUsageSection function to clean up the code and improve 
readability. This change enhances the maintainability of the 
codebase by removing unnecessary output during execution.