### PR TITLE
support-array-type-extraction

### DIFF
--- a/examples/file/bicep/README.md
+++ b/examples/file/bicep/README.md
@@ -56,9 +56,9 @@ module reference_name 'path_to_module | container_registry_reference' = {
 
 ## User Defined Functions (UDFs)
 
-| Name | Description |
-| --- | --- |
-| double | Doubles a positive integer. |
+| Name | Description | Output Type |
+| --- | --- | --- |
+| double | Doubles a positive integer. | positiveInt (uddt) |
 
 ## Variables
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -33,7 +33,7 @@ const (
 
 // rootCmd represents the base command when called without any subcommands.
 var rootCmd = &cobra.Command{
-	Version: "v1.3.2",
+	Version: "v1.4.0",
 	Use:     "bicep-docs",
 	Short:   "bicep-docs is a command-line tool that generates documentation for Bicep templates.",
 	Long: `bicep-docs is a command-line tool that generates documentation for Bicep templates.

--- a/internal/markdown/create_test.go
+++ b/internal/markdown/create_test.go
@@ -28,7 +28,9 @@ func TestCreateFile(t *testing.T) {
 	templateName := "test"
 	templateDescription := "This is a test template."
 	parameterDescription := "This is a test parameter."
-	outputDescription := "This is a test output."
+	stringType := "string"
+	positiveIntType := "#/definitions/positive_int"
+
 	basicTemplate := &types.Template{
 		FileName: "test.bicep",
 		Modules: []types.Module{
@@ -82,7 +84,7 @@ func TestCreateFile(t *testing.T) {
 				Name: "test_output",
 				Type: "string",
 				Metadata: &types.Metadata{
-					Description: &outputDescription,
+					Description: func() *string { s := "This is a test output."; return &s }(),
 				},
 			},
 		},
@@ -131,20 +133,54 @@ func TestCreateFile(t *testing.T) {
 					Description: func() *string { s := "This is an optional parameter."; return &s }(),
 				},
 			},
+			{
+				Name:         "string_array",
+				Type:         "array",
+				Items:        func() *types.Items { i := &types.Items{Type: &stringType}; return i }(),
+				DefaultValue: []string{},
+				Metadata: &types.Metadata{
+					Description: func() *string { s := "This is a string array parameter."; return &s }(),
+				},
+			},
+			{
+				Name:  "pint_array",
+				Type:  "array",
+				Items: func() *types.Items { i := &types.Items{Ref: &positiveIntType}; return i }(),
+				Metadata: &types.Metadata{
+					Description: func() *string { s := "This is a positive int custom type array parameter."; return &s }(),
+				},
+			},
+			{
+				Name: "simple_array",
+				Type: "array",
+				Metadata: &types.Metadata{
+					Description: func() *string { s := "This is simple array parameter."; return &s }(),
+				},
+			},
 		},
 		UserDefinedDataTypes: []types.UserDefinedDataType{
 			{
 				Name: "pint",
-				Type: "#/definitions/positiveInt",
+				Type: positiveIntType,
 				Metadata: &types.Metadata{
 					Description: func() *string { s := "This is a user defined type (alias)."; return &s }(),
 				},
 			},
 			{
-				Name: "positiveInt",
+				Name: "positive_int",
 				Type: "int",
 				Metadata: &types.Metadata{
 					Description: func() *string { s := "This is a user defined type."; return &s }(),
+				},
+			},
+			{
+				Name: "string_array",
+				Type: "array",
+				Items: &types.Items{
+					Type: &stringType,
+				},
+				Metadata: &types.Metadata{
+					Description: func() *string { s := "This is a user defined type with array items."; return &s }(),
 				},
 			},
 			{
@@ -163,9 +199,19 @@ func TestCreateFile(t *testing.T) {
 					},
 					{
 						Name: "property_2",
-						Type: "#/definitions/positiveInt",
+						Type: positiveIntType,
 						Metadata: &types.Metadata{
 							Description: func() *string { s := "This is another property of a user defined type which uses ref."; return &s }(),
+						},
+					},
+					{
+						Name: "property_3",
+						Type: "array",
+						Items: &types.Items{
+							Ref: &positiveIntType,
+						},
+						Metadata: &types.Metadata{
+							Description: func() *string { s := "This is a property of a user defined type with array items."; return &s }(),
 						},
 					},
 				},
@@ -173,15 +219,33 @@ func TestCreateFile(t *testing.T) {
 		},
 		UserDefinedFunctions: []types.UserDefinedFunction{
 			{
-				Name: "buildUrl",
+				Name: "build_url",
+				Output: types.Output{
+					Type: stringType,
+				},
 				Metadata: &types.Metadata{
 					Description: func() *string { s := "This is a user defined function."; return &s }(),
 				},
 			},
 			{
 				Name: "double",
+				Output: types.Output{
+					Type: positiveIntType,
+				},
 				Metadata: &types.Metadata{
 					Description: func() *string { s := "This is a user defined function with uddts."; return &s }(),
+				},
+			},
+			{
+				Name: "get_string_array",
+				Output: types.Output{
+					Type: "array",
+					Items: &types.Items{
+						Type: &stringType,
+					},
+				},
+				Metadata: &types.Metadata{
+					Description: func() *string { s := "This is a user defined function with array items as output."; return &s }(),
 				},
 			},
 		},
@@ -193,10 +257,20 @@ func TestCreateFile(t *testing.T) {
 		},
 		Outputs: []types.Output{
 			{
-				Name: "test_output",
-				Type: "#/definitions/positiveInt",
+				Name: "pint",
+				Type: positiveIntType,
 				Metadata: &types.Metadata{
-					Description: &outputDescription,
+					Description: func() *string { s := "This is an output with uddt."; return &s }(),
+				},
+			},
+			{
+				Name: "pint_array",
+				Type: "array",
+				Items: &types.Items{
+					Ref: &positiveIntType,
+				},
+				Metadata: &types.Metadata{
+					Description: func() *string { s := "This is an output with uddt array items."; return &s }(),
 				},
 			},
 		},

--- a/internal/markdown/testdata/extended.md
+++ b/internal/markdown/testdata/extended.md
@@ -14,10 +14,13 @@ module reference_name 'path_to_module | container_registry_reference' = {
   params: {
     // Required parameters
     required:
+    pint_array:
+    simple_array:
 
     // Optional parameters
     nullable: null
     optional: 'test'
+    string_array: []
   }
 }
 ```
@@ -43,13 +46,17 @@ module reference_name 'path_to_module | container_registry_reference' = {
 | required | string | This is a required parameter. |  |
 | nullable | string | This is a nullable parameter. | null |
 | optional | string | This is an optional parameter. | "test" |
+| string_array | string[] | This is a string array parameter. | [] |
+| pint_array | positive_int[] (uddt) | This is a positive int custom type array parameter. |  |
+| simple_array | array | This is simple array parameter. |  |
 
 ## User Defined Data Types (UDDTs)
 
 | Name | Type | Description | Properties |
 | --- | --- | --- | --- |
-| pint | positiveInt (uddt) | This is a user defined type (alias). |  |
-| positiveInt | int | This is a user defined type. |  |
+| pint | positive_int (uddt) | This is a user defined type (alias). |  |
+| positive_int | int | This is a user defined type. |  |
+| string_array | string[] | This is a user defined type with array items. |  |
 | custom_type | object | This is a user defined type with properties. | [View Properties](#custom_type) |
 
 ### custom_type
@@ -57,14 +64,16 @@ module reference_name 'path_to_module | container_registry_reference' = {
 | Name | Type | Description |
 | --- | --- | --- |
 | property1 | string | This is a property of a user defined type. |
-| property_2 | positiveInt (uddt) | This is another property of a user defined type which uses ref. |
+| property_2 | positive_int (uddt) | This is another property of a user defined type which uses ref. |
+| property_3 | positive_int[] (uddt) | This is a property of a user defined type with array items. |
 
 ## User Defined Functions (UDFs)
 
-| Name | Description |
-| --- | --- |
-| buildUrl | This is a user defined function. |
-| double | This is a user defined function with uddts. |
+| Name | Description | Output Type |
+| --- | --- | --- |
+| build_url | This is a user defined function. | string |
+| double | This is a user defined function with uddts. | positive_int (uddt) |
+| get_string_array | This is a user defined function with array items as output. | string[] |
 
 ## Variables
 
@@ -76,4 +85,5 @@ module reference_name 'path_to_module | container_registry_reference' = {
 
 | Name | Type | Description |
 | --- | --- | --- |
-| test_output | positiveInt (uddt) | This is a test output. |
+| pint | positive_int (uddt) | This is an output with uddt. |
+| pint_array | positive_int[] (uddt) | This is an output with uddt array items. |

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -22,6 +22,13 @@ type Metadata struct {
 	Description *string `json:"description"`
 }
 
+// Items represents the array item type information.
+// The type field can be either a type or a $ref.
+type Items struct {
+	Type *string `json:"type"`
+	Ref  *string `json:"$ref"`
+}
+
 // Module is a struct that contains the information about a module.
 // A module has a symbolic name, a source, and an optional description.
 //
@@ -52,47 +59,53 @@ type Resource struct {
 }
 
 // Parameter is a struct that contains the information about a parameter.
-// A parameter has a name, type, an optional default value, nullable flag, and an optional metadata part.
+// A parameter has a name, type, an optional default value, items (for array types), nullable flag, and an optional metadata part.
 //
 // The name is the name of the parameter.
 // The type is the type of the parameter (e.g. "string" or even a user defined type).
 // The default value is the optional default value of the parameter.
+// The items part is the optional items part of the parameter (for array types).
 // The nullable flag indicates if the parameter can be null.
 // The metadata part is the optional metadata part of the parameter (just the description).
 type Parameter struct {
 	Name         string    `json:"-"`
 	Type         string    `json:"-"`
 	DefaultValue any       `json:"defaultValue"`
+	Items        *Items    `json:"items"`
 	Nullable     bool      `json:"nullable"`
 	Metadata     *Metadata `json:"metadata"`
 }
 
 // UserDefinedDataType (UDDT) is a struct that contains the information about a user defined data type.
-// A user defined data type has a name, type, nullable flag, list of properties, and an optional metadata part.
+// A user defined data type has a name, type, items (for array types), nullable flag, properties, and an optional metadata part.
 //
 // The name is the name of the user defined data type.
 // The type is the type of the user defined data type (e.g. "object" or even including other user defined types).
+// The items part is the optional items part of the user defined data type (for array types).
 // The nullable flag indicates if the user defined data type can be null.
 // The properties are the properties of the user defined data type (e.g. fields in an object).
 // The metadata part is the optional metadata part of the user defined data type (just the description).
 type UserDefinedDataType struct {
 	Name       string                        `json:"-"`
 	Type       string                        `json:"-"`
+	Items      *Items                        `json:"items"`
 	Nullable   bool                          `json:"nullable"`
 	Properties []UserDefinedDataTypeProperty `json:"-"`
 	Metadata   *Metadata                     `json:"metadata"`
 }
 
 // UserDefinedDataTypeProperty is a struct that contains the information about a property of a user defined data type.
-// A property has a name, type, nullable flag, and an optional metadata part.
+// A property has a name, type, items (for array types), nullable flag, and an optional metadata part.
 //
 // The name is the name of the property.
 // The type is the type of the property (e.g. "string" or even a user defined type).
+// The items part is the optional items part of the property (for array types).
 // The nullable flag indicates if the property can be null.
 // The metadata part is the optional metadata part of the property (just the description).
 type UserDefinedDataTypeProperty struct {
 	Name     string    `json:"-"`
 	Type     string    `json:"-"`
+	Items    *Items    `json:"items"`
 	Nullable bool      `json:"nullable"`
 	Metadata *Metadata `json:"metadata"`
 }
@@ -124,15 +137,17 @@ type Variable struct {
 }
 
 // Output is a struct that contains the information about an output.
-// An output has a name, type, nullable flag, and an optional metadata part.
+// An output has a name, type, items (for array types), nullable flag, and an optional metadata part.
 //
 // The name is the name of the output.
 // The type is the type of the output (e.g. "string").
+// The items part is the optional items part of the output (for array types).
 // The nullable flag indicates if the output can be null.
 // The metadata part is the optional metadata part of the output (just the description).
 type Output struct {
 	Name     string    `json:"-"`
 	Type     string    `json:"-"`
+	Items    *Items    `json:"items"`
 	Nullable bool      `json:"nullable"`
 	Metadata *Metadata `json:"metadata"`
 }

--- a/internal/types/unmarshal.go
+++ b/internal/types/unmarshal.go
@@ -9,6 +9,7 @@ import (
 
 var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
+// unmarshalTypeOrRef unmarshals a JSON object into a type or a $ref.
 func unmarshalTypeOrRef(data []byte) (string, error) {
 	var result struct {
 		Type string `json:"type"`


### PR DESCRIPTION
## Description
This pull request enhances type extraction functionality, particularly for array types. The `extractType` function has been updated to capture detailed item information, improving type representation in the generated documentation. Additionally, related functions now ensure item details are properly passed when generating sections for parameters, outputs, and user-defined data types.

The user-defined functions table has also been updated to include function output types for better clarity.

Furthermore, output and property definitions in the test files have been refactored for consistency and readability. This includes standardizing output names and types, aligning with naming conventions, and refining descriptions for improved comprehension. New properties and user-defined functions have been added to support additional functionality and ensure comprehensive testing.

Lastly, the root command version has been incremented from `v1.3.2` to `v1.4.0` to reflect these enhancements and keep users informed of the latest updates.

## Related Issue
#54

## Motivation and Context
These changes are required to enhance the type extraction capabilities of the tool, allowing for better documentation and understanding of array types and UDDTs. The refactoring of tests ensures that the code remains maintainable and clear, while the version bump keeps users informed of the latest updates.

## How Has This Been Tested?
The changes have been tested by running the updated test suite, which includes the refactored output and property definitions. All tests passed successfully, confirming that the enhancements do not introduce any regressions and that the new functionality works as intended.

## Screenshots (if appropriate)

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.